### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -30,6 +30,14 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :edit
+   end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path
     else
-      render :edit
+      render :show
    end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
       <% end %>
 
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, except: [:destroy]
+  resources :items
 end


### PR DESCRIPTION
What
- furimaアプリの商品削除機能の実装

Why
- furimaアプリの商品削除機能の実装するため

画像:
ユーザー :hogeでログイン
https://gyazo.com/e20df223bcecd5db77e6d2f3539334ca

削除前の商品一覧
https://gyazo.com/e321a22923890cbeb09cdfd9b064327f

出品者だけが商品詳細ページに編集・削除ボタンがある
https://gyazo.com/8aefec9403d8af47ea8b439b536fb2af

商品詳細ページの削除を実行するとトップ画面に戻り、削除した商品が一覧からなくなっている
https://gyazo.com/a346a84719e367ecb6be8d137f0a72ab